### PR TITLE
refactor(pg_lsp): use tokio, partially remove crossbeam channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "text-size",
  "threadpool",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2518,6 +2519,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.71",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +226,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,11 +335,11 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "58e804ac3194a48bb129643eb1d62fcc20d18c6b8c181704489353d13120bcd1"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -817,6 +841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1486,7 @@ dependencies = [
  "sqlx",
  "text-size",
  "threadpool",
+ "tokio",
 ]
 
 [[package]]
@@ -1878,6 +1918,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -2451,6 +2497,28 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
 
 [[package]]
 name = "tracing"

--- a/crates/pg_lsp/Cargo.toml
+++ b/crates/pg_lsp/Cargo.toml
@@ -33,6 +33,7 @@ pg_schema_cache.workspace = true
 pg_workspace.workspace = true
 pg_diagnostics.workspace = true
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-util = "0.7.12"
 
 [dev-dependencies]
 

--- a/crates/pg_lsp/Cargo.toml
+++ b/crates/pg_lsp/Cargo.toml
@@ -32,6 +32,7 @@ pg_base_db.workspace = true
 pg_schema_cache.workspace = true
 pg_workspace.workspace = true
 pg_diagnostics.workspace = true
+tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "sync"] }
 
 [dev-dependencies]
 

--- a/crates/pg_lsp/src/client.rs
+++ b/crates/pg_lsp/src/client.rs
@@ -50,6 +50,14 @@ impl LspClient {
         Ok(())
     }
 
+    /// This will ignore any errors that occur while sending the notification.
+    pub fn send_info_notification(&self, message: &str) {
+        let _ = self.send_notification::<ShowMessage>(ShowMessageParams {
+            message: message.into(),
+            typ: MessageType::INFO,
+        });
+    }
+
     pub fn send_request<R>(&self, params: R::Params) -> Result<R::Result>
     where
         R: lsp_types::request::Request,

--- a/crates/pg_lsp/src/client/client_flags.rs
+++ b/crates/pg_lsp/src/client/client_flags.rs
@@ -1,10 +1,36 @@
+use lsp_types::InitializeParams;
+
 /// Contains information about the client's capabilities.
 /// This is used to determine which features the server can use.
 #[derive(Debug, Clone)]
 pub struct ClientFlags {
-    /// If `true`, the server can pull the configuration from the client.
-    pub configuration_pull: bool,
+    /// If `true`, the server can pull configuration from the client.
+    pub has_configuration: bool,
 
-    /// If `true`, the client notifies the server when the configuration changes.
-    pub configuration_push: bool,
+    /// If `true`, the client notifies the server when its configuration changes.
+    pub will_push_configuration: bool,
+}
+
+impl ClientFlags {
+    pub(crate) fn from_initialize_request_params(params: &InitializeParams) -> Self {
+        let has_configuration = params
+            .capabilities
+            .workspace
+            .as_ref()
+            .and_then(|w| w.configuration)
+            .unwrap_or(false);
+
+        let will_push_configuration = params
+            .capabilities
+            .workspace
+            .as_ref()
+            .and_then(|w| w.did_change_configuration)
+            .and_then(|c| c.dynamic_registration)
+            .unwrap_or(false);
+
+        Self {
+            has_configuration,
+            will_push_configuration,
+        }
+    }
 }

--- a/crates/pg_lsp/src/db_connection.rs
+++ b/crates/pg_lsp/src/db_connection.rs
@@ -1,0 +1,61 @@
+use pg_schema_cache::SchemaCache;
+use sqlx::{postgres::PgListener, PgPool};
+
+#[derive(Debug)]
+pub(crate) struct DbConnection {
+    pub pool: PgPool,
+    connection_string: String,
+}
+
+impl DbConnection {
+    pub(crate) async fn new(connection_string: String) -> Result<Self, sqlx::Error> {
+        let pool = PgPool::connect(&connection_string).await?;
+        Ok(Self {
+            pool,
+            connection_string: connection_string,
+        })
+    }
+
+    pub(crate) async fn refresh_db_connection(
+        self,
+        connection_string: Option<String>,
+    ) -> anyhow::Result<Self> {
+        if connection_string.is_none()
+            || connection_string.as_ref() == Some(&self.connection_string)
+        {
+            return Ok(self);
+        }
+
+        self.pool.close().await;
+
+        let conn = DbConnection::new(connection_string.unwrap()).await?;
+
+        Ok(conn)
+    }
+
+    pub(crate) async fn start_listening<F>(&self, on_schema_update: F) -> anyhow::Result<()>
+    where
+        F: Fn() -> () + Send + 'static,
+    {
+        let mut listener = PgListener::connect_with(&self.pool).await?;
+        listener.listen_all(["postgres_lsp", "pgrst"]).await?;
+
+        loop {
+            match listener.recv().await {
+                Ok(notification) => {
+                    if notification.payload().to_string() == "reload schema" {
+                        on_schema_update();
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Listener error: {}", e);
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn get_schema_cache(&self) -> SchemaCache {
+        SchemaCache::load(&self.pool).await
+    }
+}

--- a/crates/pg_lsp/src/lib.rs
+++ b/crates/pg_lsp/src/lib.rs
@@ -1,3 +1,4 @@
 mod client;
+mod db_connection;
 pub mod server;
 mod utils;

--- a/crates/pg_lsp/src/main.rs
+++ b/crates/pg_lsp/src/main.rs
@@ -4,8 +4,8 @@ use pg_lsp::server::Server;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let (connection, threads) = Connection::stdio();
-    let server = Server::init(connection)?;
 
+    let server = Server::init(connection)?;
     server.run().await?;
     threads.join()?;
 

--- a/crates/pg_lsp/src/main.rs
+++ b/crates/pg_lsp/src/main.rs
@@ -1,9 +1,12 @@
 use lsp_server::Connection;
 use pg_lsp::server::Server;
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let (connection, threads) = Connection::stdio();
-    Server::init(connection)?;
+    let server = Server::init(connection)?;
+
+    server.run().await?;
     threads.join()?;
 
     Ok(())

--- a/crates/pg_lsp/src/server.rs
+++ b/crates/pg_lsp/src/server.rs
@@ -722,7 +722,7 @@ impl Server {
             self.pull_options();
         } else {
             let options = self.client.parse_options(params.settings)?;
-            self.update_db_connection(options);
+            self.update_db_connection(options)?;
         }
 
         Ok(())
@@ -770,8 +770,7 @@ impl Server {
             Message::Notification(notification) => {
                 dispatch::NotificationDispatcher::new(notification)
                     .on::<DidChangeConfiguration, _>(|params| {
-                        self.did_change_configuration(params);
-                        Ok(())
+                        self.did_change_configuration(params)
                     })?
                     .on::<DidCloseTextDocument, _>(|params| self.did_close(params))?
                     .on::<DidOpenTextDocument, _>(|params| self.did_open(params))?

--- a/crates/pg_lsp/src/server.rs
+++ b/crates/pg_lsp/src/server.rs
@@ -758,7 +758,7 @@ impl Server {
         });
     }
 
-    fn refresh_schema_cache(&self) {
+    async fn refresh_schema_cache(&self) {
         if self.db_conn.is_none() {
             return;
         }
@@ -767,17 +767,15 @@ impl Server {
         let conn = self.db_conn.as_ref().unwrap().pool.clone();
         let client = self.client.clone();
 
-        async_std::task::spawn(async move {
-            client
-                .send_notification::<ShowMessage>(ShowMessageParams {
-                    typ: lsp_types::MessageType::INFO,
-                    message: "Refreshing schema cache...".to_string(),
-                })
-                .unwrap();
-            let schema_cache = SchemaCache::load(&conn).await;
-            tx.send(InternalMessage::SetSchemaCache(schema_cache))
-                .unwrap();
-        });
+        client
+            .send_notification::<ShowMessage>(ShowMessageParams {
+                typ: lsp_types::MessageType::INFO,
+                message: "Refreshing schema cache...".to_string(),
+            })
+            .unwrap();
+        let schema_cache = SchemaCache::load(&conn).await;
+        tx.send(InternalMessage::SetSchemaCache(schema_cache))
+            .unwrap();
     }
 
     fn did_change_configuration(

--- a/crates/pg_lsp/src/server.rs
+++ b/crates/pg_lsp/src/server.rs
@@ -216,6 +216,7 @@ impl Server {
             || self
                 .db_conn
                 .as_ref()
+                // if the connection is already connected to the same database, do nothing
                 .is_some_and(|c| c.connected_to(options.db_connection_string.as_ref().unwrap()))
         {
             return Ok(());
@@ -257,8 +258,7 @@ impl Server {
             .listen_for_schema_updates(move |schema_cache| {
                 internal_tx
                     .send(InternalMessage::SetSchemaCache(schema_cache))
-                    .unwrap();
-                // TODO: handle result
+                    .expect("LSP Server: Failed to send internal message.");
             })
             .await?;
 

--- a/crates/pg_lsp/src/server.rs
+++ b/crates/pg_lsp/src/server.rs
@@ -801,14 +801,14 @@ impl Server {
                 self.publish_diagnostics(uri)?;
             }
             InternalMessage::SetOptions(options) => {
-                self.update_db_connection(options);
+                self.update_db_connection(options)?;
             }
             InternalMessage::SetDatabaseConnection(conn) => {
                 let current = self.db_conn.replace(conn);
                 if current.is_some() {
                     current.unwrap().close().await
                 }
-                self.listen_for_schema_updates();
+                self.listen_for_schema_updates().await?;
             }
         }
 

--- a/crates/pg_lsp/src/server/debouncer/thread.rs
+++ b/crates/pg_lsp/src/server/debouncer/thread.rs
@@ -8,7 +8,6 @@ use super::buffer::{EventBuffer, Get, State};
 struct DebouncerThread<B> {
     mutex: Arc<Mutex<B>>,
     thread: JoinHandle<()>,
-    stopped: Arc<AtomicBool>,
 }
 
 impl<B> DebouncerThread<B> {
@@ -36,13 +35,7 @@ impl<B> DebouncerThread<B> {
         Self {
             mutex,
             thread,
-            stopped,
         }
-    }
-
-    fn stop(self) -> JoinHandle<()> {
-        self.stopped.store(true, Ordering::Relaxed);
-        self.thread
     }
 }
 
@@ -67,13 +60,6 @@ impl<T> EventDebouncer<T> {
 
     pub fn clear(&self) {
         self.0.mutex.lock().unwrap().clear();
-    }
-
-    /// Signals the debouncer thread to quit and returns a
-    /// [std::thread::JoinHandle] which can be `.join()`ed in the consumer
-    /// thread. The common idiom is: `debouncer.stop().join().unwrap();`
-    pub fn stop(self) -> JoinHandle<()> {
-        self.0.stop()
     }
 }
 

--- a/crates/pg_lsp/src/server/debouncer/thread.rs
+++ b/crates/pg_lsp/src/server/debouncer/thread.rs
@@ -32,10 +32,7 @@ impl<B> DebouncerThread<B> {
                 }
             }
         });
-        Self {
-            mutex,
-            thread,
-        }
+        Self { mutex, thread }
     }
 }
 

--- a/crates/pg_lsp/src/utils/from_proto.rs
+++ b/crates/pg_lsp/src/utils/from_proto.rs
@@ -1,5 +1,3 @@
-use crate::client::client_flags::ClientFlags;
-
 use super::line_index_ext::LineIndexExt;
 use pg_base_db::{Change, Document};
 
@@ -16,24 +14,4 @@ pub fn content_changes(
             text: change.text.clone(),
         })
         .collect()
-}
-
-pub fn client_flags(capabilities: lsp_types::ClientCapabilities) -> ClientFlags {
-    let configuration_pull = capabilities
-        .workspace
-        .as_ref()
-        .and_then(|cap| cap.configuration)
-        .unwrap_or(false);
-
-    let configuration_push = capabilities
-        .workspace
-        .as_ref()
-        .and_then(|cap| cap.did_change_configuration)
-        .and_then(|cap| cap.dynamic_registration)
-        .unwrap_or(false);
-
-    ClientFlags {
-        configuration_pull,
-        configuration_push,
-    }
 }

--- a/crates/pg_schema_cache/src/lib.rs
+++ b/crates/pg_schema_cache/src/lib.rs
@@ -4,11 +4,11 @@
 #![feature(future_join)]
 
 mod functions;
-mod versions;
 mod schema_cache;
 mod schemas;
 mod tables;
 mod types;
+mod versions;
 
 use sqlx::postgres::PgPool;
 

--- a/crates/pg_schema_cache/src/lib.rs
+++ b/crates/pg_schema_cache/src/lib.rs
@@ -4,11 +4,11 @@
 #![feature(future_join)]
 
 mod functions;
+mod versions;
 mod schema_cache;
 mod schemas;
 mod tables;
 mod types;
-mod versions;
 
 use sqlx::postgres::PgPool;
 

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -137,10 +137,7 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
 }
 
 fn install_server(sh: &Shell) -> anyhow::Result<()> {
-    let cmd = cmd!(
-        sh,
-        "cargo install --path crates/pg_lsp --locked --force"
-    );
+    let cmd = cmd!(sh, "cargo install --path crates/pg_lsp --locked --force");
     cmd.run()?;
     Ok(())
 }


### PR DESCRIPTION
This PR introduces `tokio` into the `pg_lsp` crate and tries to remove the `crossbeam` dependency from the LspServer.

- All separate tasks are now spawned with tokio
- All separate tasks listen for a cancel_token that allows us to shut down the server without dangling tasks
- The database connection now lives in its own file
- The ClientFlags now live in its own file
-  I refactored the setup logic a bit, for example, the `InitializeRequest` flow now lives in its own function
- I split up the internal message loop into `process_messages`, `handle_message` and `handle_internal_message`
- Schema Updates & DbConnectionResets are now done via channels & internal messages
- and, last but not least, I added a tiny `client.send_info_message` helper. 🤓

Next steps:
- [ ] replace the `lsp_types`  with [tower_lsp](https://github.com/ebkalderon/tower-lsp), which should work better with tokio
- [ ] if possible, use tokio with both the `LspClient` and the `EventDebouncer` (haven't looked into that yet)
- [ ] migrate the lsp-server to an architecture that uses daemons, such as biome's

Looking forward to your feedback! 
