### PR TITLE
fix(vscode): extension command, server crate path

### DIFF
--- a/editors/code/.prettierrc.js
+++ b/editors/code/.prettierrc.js
@@ -1,7 +1,8 @@
 module.exports = {
-  // use 100 because it's Rustfmt's default
-  // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
-  printWidth: 100,
-  singleQuote: true,
-  tabWidth: 4,
+    // use 100 because it's Rustfmt's default
+    // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
+    printWidth: 100,
+    singleQuote: true,
+    tabWidth: 4,
+    trailingComma: 'none'
 };

--- a/editors/code/.prettierrc.js
+++ b/editors/code/.prettierrc.js
@@ -1,5 +1,7 @@
 module.exports = {
-    // use 100 because it's Rustfmt's default
-    // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
-    printWidth: 100,
+  // use 100 because it's Rustfmt's default
+  // https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#max_width
+  printWidth: 100,
+  singleQuote: true,
+  tabWidth: 4,
 };

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -4,7 +4,7 @@ import {
     Executable,
     LanguageClient,
     LanguageClientOptions,
-    ServerOptions,
+    ServerOptions
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
@@ -13,21 +13,28 @@ export function activate(context: ExtensionContext) {
     // If the extension is launched in debug mode then the debug server options are used
     // Otherwise the run options are used
     const run: Executable = {
-        command: 'pglsp',
+        command: 'pglsp'
     };
     const serverOptions: ServerOptions = {
         run,
-        debug: run,
+        debug: run
     };
 
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
-        documentSelector: [{ scheme: 'file', language: 'sql' }],
+        documentSelector: [
+            { scheme: 'file', language: 'sql' }
+        ]
     };
 
     // Create the language client and start the client.
-    client = new LanguageClient('postgres_lsp', 'Postgres LSP', serverOptions, clientOptions);
+    client = new LanguageClient(
+        'postgres_lsp',
+        'Postgres LSP',
+        serverOptions,
+        clientOptions
+    );
 
     // Start the client. This will also launch the server
     client.start();

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -1,46 +1,41 @@
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext } from "vscode";
 
 import {
-    Executable,
-    LanguageClient,
-    LanguageClientOptions,
-    ServerOptions,
-} from 'vscode-languageclient/node';
+  Executable,
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-    // If the extension is launched in debug mode then the debug server options are used
-    // Otherwise the run options are used
-    const run: Executable = {
-        command: 'postgres_lsp',
-    };
-    const serverOptions: ServerOptions = {
-        run,
-        debug: run
-    };
+  // If the extension is launched in debug mode then the debug server options are used
+  // Otherwise the run options are used
+  const run: Executable = {
+    command: "pglsp",
+  };
+  const serverOptions: ServerOptions = {
+    run,
+    debug: run,
+  };
 
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-        // Register the server for plain text documents
-        documentSelector: [{ scheme: 'file', language: 'sql' }]
-    };
+  // Options to control the language client
+  const clientOptions: LanguageClientOptions = {
+    // Register the server for plain text documents
+    documentSelector: [{ scheme: "file", language: "sql" }],
+  };
 
-    // Create the language client and start the client.
-    client = new LanguageClient(
-        'postgres_lsp',
-        'Postgres LSP',
-        serverOptions,
-        clientOptions
-    );
+  // Create the language client and start the client.
+  client = new LanguageClient("postgres_lsp", "Postgres LSP", serverOptions, clientOptions);
 
-    // Start the client. This will also launch the server
-    client.start();
+  // Start the client. This will also launch the server
+  client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
-    }
-    return client.stop();
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -1,41 +1,41 @@
-import { ExtensionContext } from "vscode";
+import { ExtensionContext } from 'vscode';
 
 import {
-  Executable,
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-} from "vscode-languageclient/node";
+    Executable,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+} from 'vscode-languageclient/node';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-  // If the extension is launched in debug mode then the debug server options are used
-  // Otherwise the run options are used
-  const run: Executable = {
-    command: "pglsp",
-  };
-  const serverOptions: ServerOptions = {
-    run,
-    debug: run,
-  };
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    const run: Executable = {
+        command: 'pglsp',
+    };
+    const serverOptions: ServerOptions = {
+        run,
+        debug: run,
+    };
 
-  // Options to control the language client
-  const clientOptions: LanguageClientOptions = {
-    // Register the server for plain text documents
-    documentSelector: [{ scheme: "file", language: "sql" }],
-  };
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+        // Register the server for plain text documents
+        documentSelector: [{ scheme: 'file', language: 'sql' }],
+    };
 
-  // Create the language client and start the client.
-  client = new LanguageClient("postgres_lsp", "Postgres LSP", serverOptions, clientOptions);
+    // Create the language client and start the client.
+    client = new LanguageClient('postgres_lsp', 'Postgres LSP', serverOptions, clientOptions);
 
-  // Start the client. This will also launch the server
-  client.start();
+    // Start the client. This will also launch the server
+    client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  if (!client) {
-    return undefined;
-  }
-  return client.stop();
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
 }

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -139,7 +139,7 @@ fn install_client(sh: &Shell, client_opt: ClientOpt) -> anyhow::Result<()> {
 fn install_server(sh: &Shell) -> anyhow::Result<()> {
     let cmd = cmd!(
         sh,
-        "cargo install --path crates/postgres_lsp --locked --force"
+        "cargo install --path crates/pg_lsp --locked --force"
     );
     cmd.run()?;
     Ok(())


### PR DESCRIPTION
## What kind of change does this PR introduce?

When we install and use the VS Code extension, we're now installing the correct crate and running the correct binary.
I also added already-in-use, non-default settings to the `.prettierrc.js` file, so that the diff is more readable.

## What is the current behavior?

Running `cargo xtask install` fails because it's looking for a `postgres_lsp` crate; there is none. The crate is called `pg_lsp`.

Starting the VSCode extension fails because it tries to execute the `postgres_lsp` binary; it's called `pglsp`. 

## What is the new behavior?

We're installing the correct crate and executing the correct binary. 

It's working now 🥳🥳🥳:

<img width="577" alt="Screenshot 2024-10-13 at 10 45 31" src="https://github.com/user-attachments/assets/52071827-ac34-4ab8-b332-594feb20474a">

