### PR TITLE
refactor: move PgLspPath into pg_fs crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1077,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1403,7 @@ name = "pg_base_db"
 version = "0.0.0"
 dependencies = [
  "line_index",
+ "pg_fs",
  "pg_statement_splitter",
  "text-size",
 ]
@@ -1397,6 +1435,14 @@ name = "pg_diagnostics"
 version = "0.0.0"
 dependencies = [
  "text-size",
+]
+
+[[package]]
+name = "pg_fs"
+version = "0.0.0"
+dependencies = [
+ "directories",
+ "tracing",
 ]
 
 [[package]]
@@ -1477,6 +1523,7 @@ dependencies = [
  "pg_commands",
  "pg_completions",
  "pg_diagnostics",
+ "pg_fs",
  "pg_hover",
  "pg_inlay_hints",
  "pg_schema_cache",
@@ -1594,6 +1641,7 @@ dependencies = [
  "dashmap",
  "pg_base_db",
  "pg_diagnostics",
+ "pg_fs",
  "pg_hover",
  "pg_lint",
  "pg_query_ext",
@@ -1863,6 +1911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ rust-version = "1.71"
 line_index = { path = "./lib/line_index", version = "0.0.0" }
 tree_sitter_sql = { path = "./lib/tree_sitter_sql", version = "0.0.0" }
 tree-sitter = "0.20.10"
+tracing = "0.1.40"
 
 # postgres specific crates
 pg_lexer = { path = "./crates/pg_lexer", version = "0.0.0" }
+pg_fs = { path = "./crates/pg_fs", version = "0.0.0" }
 pg_diagnostics = { path = "./crates/pg_diagnostics", version = "0.0.0" }
 pg_lexer_codegen = { path = "./crates/pg_lexer_codegen", version = "0.0.0" }
 pg_statement_splitter = { path = "./crates/pg_statement_splitter", version = "0.0.0" }

--- a/crates/pg_base_db/Cargo.toml
+++ b/crates/pg_base_db/Cargo.toml
@@ -8,6 +8,7 @@ text-size = "1.1.1"
 line_index.workspace = true
 
 pg_statement_splitter.workspace = true
+pg_fs.workspace = true
 
 [dev-dependencies]
 

--- a/crates/pg_base_db/src/change.rs
+++ b/crates/pg_base_db/src/change.rs
@@ -291,7 +291,8 @@ impl DocumentChange {
 mod tests {
     use text_size::{TextRange, TextSize};
 
-    use crate::{change::Change, document::StatementRef, Document, DocumentChange, PgLspPath};
+    use crate::{change::Change, document::StatementRef, Document, DocumentChange};
+    use pg_fs::PgLspPath;
 
     #[test]
     fn test_document_apply_changes() {

--- a/crates/pg_base_db/src/document.rs
+++ b/crates/pg_base_db/src/document.rs
@@ -3,7 +3,7 @@ use std::{hash::Hash, hash::Hasher, ops::RangeBounds};
 use line_index::LineIndex;
 use text_size::{TextRange, TextSize};
 
-use crate::PgLspPath;
+use pg_fs::PgLspPath;
 
 extern crate test;
 

--- a/crates/pg_base_db/src/document.rs
+++ b/crates/pg_base_db/src/document.rs
@@ -163,8 +163,9 @@ impl Document {
 mod tests {
 
     use text_size::{TextRange, TextSize};
+    use pg_fs::PgLspPath;
 
-    use crate::{Document, PgLspPath};
+    use crate::{Document};
 
     #[test]
     fn test_statements_at_range() {

--- a/crates/pg_base_db/src/lib.rs
+++ b/crates/pg_base_db/src/lib.rs
@@ -15,8 +15,6 @@
 
 mod change;
 mod document;
-mod path;
 
 pub use change::{Change, ChangedStatement, DocumentChange, StatementChange};
 pub use document::{Document, StatementRef};
-pub use path::PgLspPath;

--- a/crates/pg_fs/Cargo.toml
+++ b/crates/pg_fs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pg_fs"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+directories       = "5.0.1"
+tracing           = { workspace = true }
+
+[dev-dependencies]
+
+[lib]
+doctest = false
+
+[features]

--- a/crates/pg_fs/src/dir.rs
+++ b/crates/pg_fs/src/dir.rs
@@ -1,0 +1,21 @@
+use directories::ProjectDirs;
+use std::{env, fs, path::PathBuf};
+use tracing::warn;
+
+pub fn ensure_cache_dir() -> PathBuf {
+    if let Some(proj_dirs) = ProjectDirs::from("dev", "supabase-community", "pglsp") {
+        // Linux: /home/alice/.cache/biome
+        // Win: C:\Users\Alice\AppData\Local\biomejs\biome\cache
+        // Mac: /Users/Alice/Library/Caches/dev.biomejs.biome
+        let cache_dir = proj_dirs.cache_dir().to_path_buf();
+        if let Err(err) = fs::create_dir_all(&cache_dir) {
+            let temp_dir = env::temp_dir();
+            warn!("Failed to create local cache directory {cache_dir:?} due to error: {err}, fallback to {temp_dir:?}");
+            temp_dir
+        } else {
+            cache_dir
+        }
+    } else {
+        env::temp_dir()
+    }
+}

--- a/crates/pg_fs/src/lib.rs
+++ b/crates/pg_fs/src/lib.rs
@@ -1,0 +1,8 @@
+//! # pg_fs
+
+mod dir;
+mod path;
+
+pub use dir::ensure_cache_dir;
+pub use path::PgLspPath;
+

--- a/crates/pg_fs/src/path.rs
+++ b/crates/pg_fs/src/path.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, path::PathBuf};
 
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct PgLspPath {
     path: PathBuf,
 }
@@ -20,3 +20,4 @@ impl PgLspPath {
         }
     }
 }
+

--- a/crates/pg_lsp/Cargo.toml
+++ b/crates/pg_lsp/Cargo.toml
@@ -25,6 +25,7 @@ text-size = "1.1.1"
 line_index.workspace = true
 
 pg_hover.workspace = true
+pg_fs.workspace = true
 pg_completions.workspace = true
 pg_inlay_hints.workspace = true
 pg_commands.workspace = true

--- a/crates/pg_lsp/src/utils.rs
+++ b/crates/pg_lsp/src/utils.rs
@@ -5,7 +5,7 @@ pub mod to_proto;
 use std::path::PathBuf;
 
 use lsp_types;
-use pg_base_db::PgLspPath;
+use pg_fs::PgLspPath;
 
 /// Convert a `lsp_types::Url` to a `PgLspPath`.
 pub(crate) fn file_path(url: &lsp_types::Url) -> PgLspPath {

--- a/crates/pg_lsp/src/utils/line_index_ext.rs
+++ b/crates/pg_lsp/src/utils/line_index_ext.rs
@@ -54,7 +54,8 @@ impl LineIndexExt for LineIndex {
 
 #[cfg(test)]
 mod tests {
-    use pg_base_db::{Document, PgLspPath};
+    use pg_base_db::Document;
+    use pg_fs::PgLspPath;
     use text_size::{TextRange, TextSize};
 
     use crate::utils::line_index_ext::LineIndexExt;

--- a/crates/pg_workspace/Cargo.toml
+++ b/crates/pg_workspace/Cargo.toml
@@ -10,6 +10,7 @@ async-std = "1.12.0"
 sqlx = { version = "0.7.3", features = [ "runtime-async-std", "tls-rustls", "postgres", "json" ] }
 
 pg_base_db.workspace =  true
+pg_fs.workspace =  true
 pg_diagnostics.workspace =  true
 pg_query_ext.workspace =  true
 pg_lint.workspace =  true

--- a/crates/pg_workspace/src/lib.rs
+++ b/crates/pg_workspace/src/lib.rs
@@ -7,7 +7,8 @@ use std::sync::{RwLock, RwLockWriteGuard};
 
 use dashmap::{DashMap, DashSet};
 use lint::Linter;
-use pg_base_db::{Document, DocumentChange, PgLspPath, StatementRef};
+use pg_base_db::{Document, DocumentChange, StatementRef};
+use pg_fs::PgLspPath;
 use pg_query::PgQueryParser;
 use pg_schema_cache::SchemaCache;
 use sqlx::PgPool;

--- a/crates/pg_workspace/src/lib.rs
+++ b/crates/pg_workspace/src/lib.rs
@@ -185,7 +185,8 @@ mod tests {
     use pg_diagnostics::Diagnostic;
     use text_size::{TextRange, TextSize};
 
-    use crate::{PgLspPath, Workspace};
+    use crate::Workspace;
+    use pg_fs::PgLspPath;
 
     #[test]
     fn test_apply_change() {


### PR DESCRIPTION
first pr towards a new Workspace create. reason for this change is that
we will need some sort of fs crate for the cli eg to setup the socket.
this is what ensure_cache_dir is for.
