### PR TITLE
fix: small bug in whitespace_tokens, added a few tests for such bugs.

### DIFF
--- a/crates/pg_lexer/src/lib.rs
+++ b/crates/pg_lexer/src/lib.rs
@@ -89,7 +89,7 @@ fn whitespace_tokens(input: &str) -> VecDeque<Token> {
         } else if let Some(tab) = cap.name("tab") {
             tokens.push_back(Token {
                 token_type: TokenType::Whitespace,
-                kind: SyntaxKind::Newline,
+                kind: SyntaxKind::Tab,
                 text: tab.as_str().to_string(),
                 span: TextRange::new(
                     TextSize::from(u32::try_from(tab.start()).unwrap()),
@@ -176,6 +176,27 @@ pub fn lex(text: &str) -> Vec<Token> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tab_tokens() {
+        let input = "select\t1";
+        let tokens = lex(input);
+        assert_eq!(tokens[1].kind, SyntaxKind::Tab);
+    }
+
+    #[test]
+    fn test_newline_tokens() {
+        let input = "select\n1";
+        let tokens = lex(input);
+        assert_eq!(tokens[1].kind, SyntaxKind::Newline);
+    }
+
+    #[test]
+    fn test_whitespace_tokens() {
+        let input = "select 1";
+        let tokens = lex(input);
+        assert_eq!(tokens[1].kind, SyntaxKind::Whitespace);
+    }
 
     #[test]
     fn test_lexer() {

--- a/crates/pg_lexer/src/lib.rs
+++ b/crates/pg_lexer/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_lexer() {
-        let input = "select 1; \n -- some comment \n select 2";
+        let input = "select 1; \n -- some comment \n select 2\t";
 
         let tokens = lex(input);
         let mut tokens_iter = tokens.iter();
@@ -248,5 +248,8 @@ mod tests {
         let token = tokens_iter.next().unwrap();
         assert_eq!(token.kind, SyntaxKind::Iconst);
         assert_eq!(token.text, "2");
+
+        let token = tokens_iter.next().unwrap();
+        assert_eq!(token.kind, SyntaxKind::Tab);
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`whitespace_tokens` adds the wrong `kind` attribute for `Token` when the regex has captured a tab (`Newline`)

## What is the new behavior?

It uses the correct `kind` attribute, `Tab`.


