### PR TITLE
avoid building skipped tests vector in every loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target/
 desktop.ini
 
 *.log
+.aider*
+.env

--- a/crates/pg_syntax/tests/pg_syntax_tests.rs
+++ b/crates/pg_syntax/tests/pg_syntax_tests.rs
@@ -15,6 +15,8 @@ const SNAPSHOTS_PATH: &str = "snapshots/data";
 #[test]
 fn valid_statements() {
     // dont do postgres regress tests for now
+    let skipped_tests: Vec<_> = SKIPPED_REGRESS_TESTS.lines().collect();
+
     for path in [VALID_STATEMENTS_PATH] {
         let mut paths: Vec<_> = fs::read_dir(path).unwrap().map(|r| r.unwrap()).collect();
         paths.sort_by_key(|dir| dir.path());
@@ -23,11 +25,7 @@ fn valid_statements() {
             let path = f.path();
             let test_name = path.file_stem().unwrap().to_str().unwrap();
 
-            if SKIPPED_REGRESS_TESTS
-                .lines()
-                .collect::<Vec<_>>()
-                .contains(&test_name)
-            {
+            if skipped_tests.contains(&test_name) {
                 continue;
             }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small test optimization.

## What is the current behavior?

`SKIPPED_REGRESS_LINES` is vectorized in every single loop (technically nested two loops deep)

## What is the new behavior?

The vector is assigned to a variable outside the loops.


