### PR TITLE
fix: change at eof

### DIFF
--- a/crates/pg_lsp/src/handlers/text_document.rs
+++ b/crates/pg_lsp/src/handlers/text_document.rs
@@ -50,8 +50,6 @@ pub(crate) async fn did_change(
     session: &Session,
     params: lsp_types::DidChangeTextDocumentParams,
 ) -> Result<(), LspError> {
-    tracing::info!("did_change: {:#?}", params);
-
     let url = params.text_document.uri;
     let version = params.text_document.version;
 

--- a/crates/pg_lsp/src/handlers/text_document.rs
+++ b/crates/pg_lsp/src/handlers/text_document.rs
@@ -1,4 +1,6 @@
-use crate::{documents::Document, session::Session, utils::apply_document_changes};
+use crate::{
+    diagnostics::LspError, documents::Document, session::Session, utils::apply_document_changes,
+};
 use anyhow::Result;
 use pg_lsp_converters::from_proto::text_range;
 use pg_workspace::workspace::{
@@ -47,13 +49,15 @@ pub(crate) async fn did_open(
 pub(crate) async fn did_change(
     session: &Session,
     params: lsp_types::DidChangeTextDocumentParams,
-) -> Result<()> {
+) -> Result<(), LspError> {
+    tracing::info!("did_change: {:#?}", params);
+
     let url = params.text_document.uri;
     let version = params.text_document.version;
 
     let pglsp_path = session.file_path(&url)?;
 
-    // we need to keep the documents here too for the line index
+    let old_doc = session.document(&url)?;
     let old_text = session.workspace.get_file_content(GetFileContentParams {
         path: pglsp_path.clone(),
     })?;
@@ -71,8 +75,6 @@ pub(crate) async fn did_change(
         &params.content_changes[start..],
     );
 
-    let new_doc = Document::new(version, &text);
-
     session.workspace.change_file(ChangeFileParams {
         path: pglsp_path,
         version,
@@ -80,14 +82,14 @@ pub(crate) async fn did_change(
             .iter()
             .map(|c| ChangeParams {
                 range: c.range.and_then(|r| {
-                    text_range(&new_doc.line_index, r, session.position_encoding()).ok()
+                    text_range(&old_doc.line_index, r, session.position_encoding()).ok()
                 }),
                 text: c.text.clone(),
             })
             .collect(),
     })?;
 
-    session.insert_document(url.clone(), new_doc);
+    session.insert_document(url.clone(), Document::new(version, &text));
 
     if let Err(err) = session.update_diagnostics(url).await {
         error!("Failed to update diagnostics: {}", err);

--- a/crates/pg_workspace/src/workspace/server/change.rs
+++ b/crates/pg_workspace/src/workspace/server/change.rs
@@ -915,7 +915,19 @@ mod tests {
             }],
         };
 
-        assert_eq!(d.apply_file_change(&change5).len(), 0);
+        let changes = d.apply_file_change(&change5);
+
+        assert!(matches!(
+            changes[0],
+            StatementChange::Deleted(Statement { .. })
+        ));
+
+        assert!(matches!(
+            changes[1],
+            StatementChange::Added(AddedStatement { .. })
+        ));
+
+        assert_eq!(changes.len(), 2);
 
         assert_eq!(
             d.content,

--- a/crates/pg_workspace/src/workspace/server/change.rs
+++ b/crates/pg_workspace/src/workspace/server/change.rs
@@ -527,7 +527,7 @@ mod tests {
                 assert_eq!(changed.old_stmt_text, "select ;");
                 assert_eq!(changed.new_stmt_text, "select");
                 assert_eq!(changed.change_text, "");
-                assert_eq!(changed.change_range, TextRange::new(32.into(), 33.into()));
+                assert_eq!(changed.change_range, TextRange::new(7.into(), 8.into()));
             }
             _ => panic!("expected modified statement"),
         }

--- a/crates/pg_workspace/src/workspace/server/change.rs
+++ b/crates/pg_workspace/src/workspace/server/change.rs
@@ -173,7 +173,6 @@ impl Document {
                 let end = end.min(content_size);
                 TextRange::new(start.min(end), end)
             },
-            // affected_range: TextRange::new(start, end.min(content_size)),
             affected_indices,
             prev_index,
             next_index,
@@ -198,8 +197,6 @@ impl Document {
 
     /// Applies a single change to the document and returns the affected statements
     fn apply_change(&mut self, change: &ChangeParams) -> Vec<StatementChange> {
-        tracing::info!("applying change: {:?}", change);
-
         // if range is none, we have a full change
         if change.range.is_none() {
             return self.apply_full_change(&change.text);


### PR DESCRIPTION
trying to fix a bug where all statements are deleted when deleting at eof. and when modifying a statement.

fixes:
- using line index of old document during change instead of new
- gracefully handling changes that are out of bounds of the current content. no idea why these are sent, but they are sometimes. instead of investigating where they come from I just added a check to ensure a TextRange is always valid.
- change_range in ModifiedStatement was not adapted to the range of the statement, causing a crash and invalid diagnostics ranges when modifying within a statement.  

ready now. no idea why I didn't finish it earlier. I was sure I already had 😅