### PR TITLE
cli ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,8 @@ name = "pg_cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "biome_deserialize",
+ "biome_deserialize_macros",
  "bpaf",
  "crossbeam",
  "dashmap 5.5.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,6 +2660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "text-size",
  "tokio",
  "toml",
@@ -3790,12 +3791,13 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
+ "getrandom",
  "once_cell",
  "rustix 0.38.42",
  "windows-sys 0.59.0",

--- a/crates/pg_cli/Cargo.toml
+++ b/crates/pg_cli/Cargo.toml
@@ -12,31 +12,33 @@ version              = "0.0.0"
 
 
 [dependencies]
-anyhow             = { workspace = true }
-bpaf               = { workspace = true, features = ["bright-color"] }
-crossbeam          = { workspace = true }
-dashmap            = "5.5.3"
-hdrhistogram       = { version = "7.5.4", default-features = false }
-path-absolutize    = { version = "3.1.1", optional = false, features = ["use_unix_paths_on_wasm"] }
-pg_analyse         = { workspace = true }
-pg_configuration   = { workspace = true }
-pg_console         = { workspace = true }
-pg_diagnostics     = { workspace = true }
-pg_flags           = { workspace = true }
-pg_fs              = { workspace = true }
-pg_lsp             = { workspace = true }
-pg_text_edit       = { workspace = true }
-pg_workspace       = { workspace = true }
-quick-junit        = "0.5.0"
-rayon              = { workspace = true }
-rustc-hash         = { workspace = true }
-serde              = { workspace = true, features = ["derive"] }
-serde_json         = { workspace = true }
-tokio              = { workspace = true, features = ["io-std", "io-util", "net", "time", "rt", "sync", "rt-multi-thread", "macros"] }
-tracing            = { workspace = true }
-tracing-appender   = "0.2.3"
-tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
-tracing-tree       = "0.4.0"
+anyhow                   = { workspace = true }
+biome_deserialize        = { workspace = true }
+biome_deserialize_macros = { workspace = true }
+bpaf                     = { workspace = true, features = ["bright-color"] }
+crossbeam                = { workspace = true }
+dashmap                  = "5.5.3"
+hdrhistogram             = { version = "7.5.4", default-features = false }
+path-absolutize          = { version = "3.1.1", optional = false, features = ["use_unix_paths_on_wasm"] }
+pg_analyse               = { workspace = true }
+pg_configuration         = { workspace = true }
+pg_console               = { workspace = true }
+pg_diagnostics           = { workspace = true }
+pg_flags                 = { workspace = true }
+pg_fs                    = { workspace = true }
+pg_lsp                   = { workspace = true }
+pg_text_edit             = { workspace = true }
+pg_workspace             = { workspace = true }
+quick-junit              = "0.5.0"
+rayon                    = { workspace = true }
+rustc-hash               = { workspace = true }
+serde                    = { workspace = true, features = ["derive"] }
+serde_json               = { workspace = true }
+tokio                    = { workspace = true, features = ["io-std", "io-util", "net", "time", "rt", "sync", "rt-multi-thread", "macros"] }
+tracing                  = { workspace = true }
+tracing-appender         = "0.2.3"
+tracing-subscriber       = { workspace = true, features = ["env-filter", "json"] }
+tracing-tree             = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
 libc  = "0.2.161"

--- a/crates/pg_cli/src/commands/check.rs
+++ b/crates/pg_cli/src/commands/check.rs
@@ -39,6 +39,7 @@ impl CommandRunner for CheckCommandPayload {
         fs: &DynRef<'_, dyn FileSystem>,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
+        // update this to find migration files
         let paths = get_files_to_process_with_cli_options(
             self.since.as_deref(),
             self.changed,

--- a/crates/pg_cli/src/execute/traverse.rs
+++ b/crates/pg_cli/src/execute/traverse.rs
@@ -481,7 +481,10 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         }
 
         // only allow .sql and .pg files for now
-        if path.extension().is_none_or(|ext| ext != "sql" && ext != "pg") {
+        if path
+            .extension()
+            .is_none_or(|ext| ext != "sql" && ext != "pg")
+        {
             return false;
         }
 

--- a/crates/pg_cli/src/execute/traverse.rs
+++ b/crates/pg_cli/src/execute/traverse.rs
@@ -456,7 +456,13 @@ impl TraversalContext for TraversalOptions<'_, '_> {
 
     fn can_handle(&self, pglsp_path: &PgLspPath) -> bool {
         let path = pglsp_path.as_path();
-        if self.fs.path_is_dir(path) || self.fs.path_is_symlink(path) {
+
+        let is_valid_file = self.fs.path_is_file(path)
+            && path
+                .extension()
+                .is_some_and(|ext| ext == "sql" || ext == "pg");
+
+        if self.fs.path_is_dir(path) || self.fs.path_is_symlink(path) || is_valid_file {
             // handle:
             // - directories
             // - symlinks
@@ -476,15 +482,7 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         }
 
         // bail on fifo and socket files
-        if !self.fs.path_is_file(path) {
-            return false;
-        }
-
-        // only allow .sql and .pg files for now
-        if path
-            .extension()
-            .is_none_or(|ext| ext != "sql" && ext != "pg")
-        {
+        if !is_valid_file {
             return false;
         }
 

--- a/crates/pg_cli/src/execute/traverse.rs
+++ b/crates/pg_cli/src/execute/traverse.rs
@@ -480,6 +480,11 @@ impl TraversalContext for TraversalOptions<'_, '_> {
             return false;
         }
 
+        // only allow .sql and .pg files for now
+        if path.extension().is_some_and(|ext| ext != "sql" && ext != "pg") {
+            return false;
+        }
+
         match self.execution.traversal_mode() {
             TraversalMode::Dummy { .. } => true,
             TraversalMode::Check { .. } => true,

--- a/crates/pg_cli/src/execute/traverse.rs
+++ b/crates/pg_cli/src/execute/traverse.rs
@@ -481,7 +481,7 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         }
 
         // only allow .sql and .pg files for now
-        if path.extension().is_some_and(|ext| ext != "sql" && ext != "pg") {
+        if path.extension().is_none_or(|ext| ext != "sql" && ext != "pg") {
             return false;
         }
 

--- a/crates/pg_cli/src/lib.rs
+++ b/crates/pg_cli/src/lib.rs
@@ -67,9 +67,6 @@ impl<'app> CliSession<'app> {
         let result = match command {
             PgLspCommand::Version(_) => commands::version::full_version(self),
             PgLspCommand::Check {
-                write,
-                fix,
-                unsafe_,
                 cli_options,
                 configuration,
                 paths,
@@ -77,19 +74,18 @@ impl<'app> CliSession<'app> {
                 staged,
                 changed,
                 since,
+                after,
             } => run_command(
                 self,
                 &cli_options,
                 CheckCommandPayload {
-                    write,
-                    fix,
-                    unsafe_,
                     configuration,
                     paths,
                     stdin_file_path,
                     staged,
                     changed,
                     since,
+                    after,
                 },
             ),
             PgLspCommand::Clean => commands::clean::clean(self),

--- a/crates/pg_cli/src/lib.rs
+++ b/crates/pg_cli/src/lib.rs
@@ -74,7 +74,6 @@ impl<'app> CliSession<'app> {
                 staged,
                 changed,
                 since,
-                after,
             } => run_command(
                 self,
                 &cli_options,
@@ -85,7 +84,6 @@ impl<'app> CliSession<'app> {
                     staged,
                     changed,
                     since,
-                    after,
                 },
             ),
             PgLspCommand::Clean => commands::clean::clean(self),

--- a/crates/pg_configuration/src/database.rs
+++ b/crates/pg_configuration/src/database.rs
@@ -1,10 +1,10 @@
-use biome_deserialize_macros::Partial;
+use biome_deserialize_macros::{Merge, Partial};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
 /// The configuration of the database connection.
 #[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
-#[partial(derive(Bpaf, Clone, Eq, PartialEq))]
+#[partial(derive(Bpaf, Clone, Eq, PartialEq, Merge))]
 #[partial(serde(rename_all = "snake_case", default, deny_unknown_fields))]
 pub struct DatabaseConfiguration {
     /// The host of the database.

--- a/crates/pg_configuration/src/files.rs
+++ b/crates/pg_configuration/src/files.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use biome_deserialize::StringSet;
-use biome_deserialize_macros::Partial;
+use biome_deserialize_macros::{Merge, Partial};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ pub const DEFAULT_FILE_SIZE_LIMIT: NonZeroU64 =
 
 /// The configuration of the filesystem
 #[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
-#[partial(derive(Bpaf, Clone, Eq, PartialEq))]
+#[partial(derive(Bpaf, Clone, Eq, PartialEq, Merge))]
 #[partial(serde(rename_all = "snake_case", default, deny_unknown_fields))]
 pub struct FilesConfiguration {
     /// The maximum allowed size for source code files in bytes. Files above
@@ -29,10 +29,6 @@ pub struct FilesConfiguration {
     /// match these patterns.
     #[partial(bpaf(hide))]
     pub include: StringSet,
-
-    /// The directory where the migration files are stored
-    #[partial(bpaf(hide))]
-    pub migration_dir: String,
 }
 
 impl Default for FilesConfiguration {
@@ -41,7 +37,6 @@ impl Default for FilesConfiguration {
             max_size: DEFAULT_FILE_SIZE_LIMIT,
             ignore: Default::default(),
             include: Default::default(),
-            migration_dir: "migrations".to_string(),
         }
     }
 }

--- a/crates/pg_configuration/src/files.rs
+++ b/crates/pg_configuration/src/files.rs
@@ -29,6 +29,10 @@ pub struct FilesConfiguration {
     /// match these patterns.
     #[partial(bpaf(hide))]
     pub include: StringSet,
+
+    /// The directory where the migration files are stored
+    #[partial(bpaf(hide))]
+    pub migration_dir: String,
 }
 
 impl Default for FilesConfiguration {
@@ -37,6 +41,7 @@ impl Default for FilesConfiguration {
             max_size: DEFAULT_FILE_SIZE_LIMIT,
             ignore: Default::default(),
             include: Default::default(),
+            migration_dir: "migrations".to_string(),
         }
     }
 }

--- a/crates/pg_configuration/src/migrations.rs
+++ b/crates/pg_configuration/src/migrations.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use biome_deserialize_macros::{Merge, Partial};
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -10,30 +8,10 @@ use serde::{Deserialize, Serialize};
 #[partial(serde(rename_all = "snake_case", default, deny_unknown_fields))]
 pub struct MigrationsConfiguration {
     /// The directory where the migration files are stored
-    #[partial(bpaf(hide))]
-    pub migration_dir: Option<String>,
+    #[partial(bpaf(long("migrations-dir")))]
+    pub migrations_dir: String,
 
-    /// The pattern used to store migration files
-    #[partial(bpaf(hide))]
-    pub migration_pattern: Option<MigrationPattern>,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Merge)]
-pub enum MigrationPattern {
-    /// The migration files are stored in the root of the migration directory
-    Root,
-    /// The migration files are stored in a subdirectory of the migration directory
-    Subdirectory,
-}
-
-impl FromStr for MigrationPattern {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "root" => Ok(Self::Root),
-            "subdirectory" => Ok(Self::Subdirectory),
-            _ => Err(format!("Invalid migration pattern: {}", s)),
-        }
-    }
+    /// Ignore any migrations before this timestamp
+    #[partial(bpaf(long("after")))]
+    pub after: u64,
 }

--- a/crates/pg_configuration/src/migrations.rs
+++ b/crates/pg_configuration/src/migrations.rs
@@ -1,0 +1,39 @@
+use std::str::FromStr;
+
+use biome_deserialize_macros::{Merge, Partial};
+use bpaf::Bpaf;
+use serde::{Deserialize, Serialize};
+
+/// The configuration of the filesystem
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize, Default)]
+#[partial(derive(Bpaf, Clone, Eq, PartialEq, Merge))]
+#[partial(serde(rename_all = "snake_case", default, deny_unknown_fields))]
+pub struct MigrationsConfiguration {
+    /// The directory where the migration files are stored
+    #[partial(bpaf(hide))]
+    pub migration_dir: Option<String>,
+
+    /// The pattern used to store migration files
+    #[partial(bpaf(hide))]
+    pub migration_pattern: Option<MigrationPattern>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Merge)]
+pub enum MigrationPattern {
+    /// The migration files are stored in the root of the migration directory
+    Root,
+    /// The migration files are stored in a subdirectory of the migration directory
+    Subdirectory,
+}
+
+impl FromStr for MigrationPattern {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "root" => Ok(Self::Root),
+            "subdirectory" => Ok(Self::Subdirectory),
+            _ => Err(format!("Invalid migration pattern: {}", s)),
+        }
+    }
+}

--- a/crates/pg_workspace/Cargo.toml
+++ b/crates/pg_workspace/Cargo.toml
@@ -39,6 +39,7 @@ tree-sitter.workspace     = true
 tree_sitter_sql.workspace = true
 
 [dev-dependencies]
+tempfile = "3.15.0"
 
 [lib]
 doctest = false

--- a/crates/pg_workspace/src/settings.rs
+++ b/crates/pg_workspace/src/settings.rs
@@ -339,11 +339,6 @@ fn to_migration_settings(
     working_directory: Option<PathBuf>,
     conf: MigrationsConfiguration,
 ) -> Option<MigrationSettings> {
-    tracing::debug!(
-        "Migrations configuration: {:?}, dir: {:?}",
-        conf,
-        working_directory
-    );
     working_directory.map(|working_directory| MigrationSettings {
         path: Some(working_directory.join(conf.migrations_dir)),
         after: Some(conf.after),

--- a/crates/pg_workspace/src/workspace/server.rs
+++ b/crates/pg_workspace/src/workspace/server.rs
@@ -1,4 +1,10 @@
-use std::{fs, future::Future, panic::RefUnwindSafe, path::Path, sync::RwLock};
+use std::{
+    fs,
+    future::Future,
+    panic::RefUnwindSafe,
+    path::{Path, PathBuf},
+    sync::RwLock,
+};
 
 use analyser::AnalyserVisitorBuilder;
 use change::StatementChange;
@@ -33,6 +39,7 @@ use super::{
 mod analyser;
 mod change;
 mod document;
+mod migration;
 mod pg_query;
 mod tree_sitter;
 
@@ -150,13 +157,31 @@ impl WorkspaceServer {
         Ok(())
     }
 
+    fn is_ignored_by_migration_config(&self, path: &Path) -> bool {
+        let set = self.settings();
+        set.as_ref()
+            .migrations
+            .as_ref()
+            .and_then(|migration_settings| {
+                tracing::info!("Checking migration settings: {:?}", migration_settings);
+                let ignore_before = migration_settings.after.as_ref()?;
+                tracing::info!("Checking migration settings: {:?}", ignore_before);
+                let migrations_dir = migration_settings.path.as_ref()?;
+                tracing::info!("Checking migration settings: {:?}", migrations_dir);
+                let migration = migration::get_migration(path, migrations_dir)?;
+
+                Some(&migration.timestamp <= ignore_before)
+            })
+            .unwrap_or(false)
+    }
+
     /// Check whether a file is ignored in the top-level config `files.ignore`/`files.include`
     fn is_ignored(&self, path: &Path) -> bool {
         let file_name = path.file_name().and_then(|s| s.to_str());
         // Never ignore PGLSP's config file regardless `include`/`ignore`
         (file_name != Some(ConfigName::pglsp_toml())) &&
             // Apply top-level `include`/`ignore
-            (self.is_ignored_by_top_level_config(path))
+            (self.is_ignored_by_top_level_config(path) || self.is_ignored_by_migration_config(path))
     }
 
     /// Check whether a file is ignored in the top-level config `files.ignore`/`files.include`

--- a/crates/pg_workspace/src/workspace/server.rs
+++ b/crates/pg_workspace/src/workspace/server.rs
@@ -163,11 +163,8 @@ impl WorkspaceServer {
             .migrations
             .as_ref()
             .and_then(|migration_settings| {
-                tracing::info!("Checking migration settings: {:?}", migration_settings);
                 let ignore_before = migration_settings.after.as_ref()?;
-                tracing::info!("Checking migration settings: {:?}", ignore_before);
                 let migrations_dir = migration_settings.path.as_ref()?;
-                tracing::info!("Checking migration settings: {:?}", migrations_dir);
                 let migration = migration::get_migration(path, migrations_dir)?;
 
                 Some(&migration.timestamp <= ignore_before)

--- a/crates/pg_workspace/src/workspace/server/migration.rs
+++ b/crates/pg_workspace/src/workspace/server/migration.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+#[derive(Debug)]
+pub(crate) struct Migration {
+    pub(crate) timestamp: u64,
+    pub(crate) name: String,
+}
+
+/// Get the migration associated with a path, if it is a migration file
+pub(crate) fn get_migration(path: &Path, migrations_dir: &Path) -> Option<Migration> {
+    // Check if path is a child of the migration directory
+    let is_child = path
+        .canonicalize()
+        .ok()
+        .and_then(|canonical_child| {
+            migrations_dir
+                .canonicalize()
+                .ok()
+                .map(|canonical_dir| canonical_child.starts_with(&canonical_dir))
+        })
+        .unwrap_or(false);
+
+    if !is_child {
+        return None;
+    }
+
+    // Try Root pattern
+    let root_migration = path
+        .file_name()
+        .and_then(|os_str| os_str.to_str())
+        .and_then(|file_name| {
+            let mut parts = file_name.splitn(2, '_');
+            let timestamp = parts.next()?.parse().ok()?;
+            let name = parts.next()?.to_string();
+            Some(Migration { timestamp, name })
+        });
+
+    if root_migration.is_some() {
+        return root_migration;
+    }
+
+    // Try Subdirectory pattern
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|os_str| os_str.to_str())
+        .and_then(|dir_name| {
+            let mut parts = dir_name.splitn(2, '_');
+            let timestamp = parts.next()?.parse().ok()?;
+            let name = parts.next()?.to_string();
+            Some(Migration { timestamp, name })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        TempDir::new().expect("Failed to create temp dir")
+    }
+
+    #[test]
+    fn test_get_migration_root_pattern() {
+        let temp_dir = setup();
+        let migrations_dir = temp_dir.path().to_path_buf();
+        let path = migrations_dir.join("1234567890_create_users.sql");
+        fs::write(&path, "").unwrap();
+
+        let migration = get_migration(&path, &migrations_dir);
+
+        assert!(migration.is_some());
+        let migration = migration.unwrap();
+        assert_eq!(migration.timestamp, 1234567890);
+        assert_eq!(migration.name, "create_users.sql");
+    }
+
+    #[test]
+    fn test_get_migration_subdirectory_pattern() {
+        let temp_dir = setup();
+        let migrations_dir = temp_dir.path().to_path_buf();
+        let subdir = migrations_dir.join("1234567890_create_users");
+        fs::create_dir(&subdir).unwrap();
+        let path = subdir.join("up.sql");
+        fs::write(&path, "").unwrap();
+
+        let migration = get_migration(&path, &migrations_dir);
+
+        assert!(migration.is_some());
+        let migration = migration.unwrap();
+        assert_eq!(migration.timestamp, 1234567890);
+        assert_eq!(migration.name, "create_users");
+    }
+
+    #[test]
+    fn test_get_migration_non_migration_file() {
+        let migrations_dir = PathBuf::from("/tmp/migrations");
+        let path = migrations_dir.join("not_a_migration.sql");
+
+        let migration = get_migration(&path, &migrations_dir);
+
+        assert!(migration.is_none());
+    }
+
+    #[test]
+    fn test_get_migration_outside_migrations_dir() {
+        let migrations_dir = PathBuf::from("/tmp/migrations");
+        let path = PathBuf::from("/tmp/other/1234567890_create_users.sql");
+
+        let migration = get_migration(&path, &migrations_dir);
+
+        assert!(migration.is_none());
+    }
+}

--- a/crates/pg_workspace/src/workspace/server/migration.rs
+++ b/crates/pg_workspace/src/workspace/server/migration.rs
@@ -24,7 +24,11 @@ pub(crate) fn get_migration(path: &Path, migrations_dir: &Path) -> Option<Migrat
         return None;
     }
 
-    // Try Root pattern
+    // we are trying to match patterns used by popular migration tools
+
+    // in the "root" pattern, all files are directly within the migrations directory
+    // and their names follow <timestamp>_<name>.sql.
+    // this is used by supabase
     let root_migration = path
         .file_name()
         .and_then(|os_str| os_str.to_str())
@@ -39,7 +43,8 @@ pub(crate) fn get_migration(path: &Path, migrations_dir: &Path) -> Option<Migrat
         return root_migration;
     }
 
-    // Try Subdirectory pattern
+    // in the "subdirectory" pattern, each migration is in a subdirectory named <timestamp>_<name>
+    // this is used by prisma and drizzle
     path.parent()
         .and_then(|parent| parent.file_name())
         .and_then(|os_str| os_str.to_str())
@@ -95,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_migration_non_migration_file() {
+    fn test_get_migration_not_timestamp_in_filename() {
         let migrations_dir = PathBuf::from("/tmp/migrations");
         let path = migrations_dir.join("not_a_migration.sql");
 

--- a/pglsp.toml
+++ b/pglsp.toml
@@ -13,6 +13,10 @@ username = "postgres"
 password = "postgres"
 database = "postgres"
 
+[migrations]
+migrations_dir = "migrations"
+after = 20230912094327
+
 [linter]
 enabled = true
 

--- a/pglsp.toml
+++ b/pglsp.toml
@@ -13,9 +13,9 @@ username = "postgres"
 password = "postgres"
 database = "postgres"
 
-[migrations]
-migrations_dir = "migrations"
-after = 20230912094327
+# [migrations]
+# migrations_dir = "migrations"
+# after = 20230912094327
 
 [linter]
 enabled = true


### PR DESCRIPTION
goal of this pr is to gear the cli towards the use case we want to support initially: running a check command on migration file(s).

after a discussion with @juleswritescode, this is the plan:

We will have one single `pgtoools check` command. by default, it will scan everything for sql files and lint it. it can be filtered by path, e.g. `pgtools check supabase/migrations` to just lint the migration directory. We will have a `migrations-dir` config option that will enable extra filtering features for files within the directory, primarily `--after` and maybe `--last-nth`. Furthermore, we will also have `--staged` and `--changed` to easily lint just the relevant migrations in a CI environment or a pre-commit hook. The existing `--include` and `--exclude` filters will continue to work. 

To enable `--after`, we will pass a `--migrations-pattern`.

how popular tools store migrations:
- drizzle: migration.sql in a directory with the timestamp and the name. ([link](https://orm.drizzle.team/docs/migrations))
- prisma: same as drizzle ([link](https://www.prisma.io/docs/orm/prisma-migrate/workflows/customizing-migrations))
- supabase: migrations dir with sql files
- typeorm: stores migrations in ts files -> not supported for now

UPDATE: I removed `--migrations-pattern` again - we just try both and check if any yield an expected value. Added `migration_dir` as well as `after` :) 

I initially tried to put it into `get_files_to_process` but that only looks at the inputs from the user and we need the traversal output to look at each file recursively. the right place for that is `can_handle`, which calls `is_path_ignored` from the workspace. the downside of my approach is that we check ignore patterns also for files, whereas before we just checked it for directories and symlinks.... an alternative would be a new workspace api aka `is_migration_ignored`, but that would conflict with `is_path_ignored` imo. 
