### PR TITLE
fix: handle unicode in lexer

### DIFF
--- a/crates/pg_workspace/src/settings.rs
+++ b/crates/pg_workspace/src/settings.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::Cow,
     num::NonZeroU64,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
@@ -13,7 +12,7 @@ use pg_configuration::{
     database::PartialDatabaseConfiguration,
     diagnostics::InvalidIgnorePattern,
     files::FilesConfiguration,
-    migrations::{self, MigrationsConfiguration, PartialMigrationsConfiguration},
+    migrations::{MigrationsConfiguration, PartialMigrationsConfiguration},
     ConfigurationDiagnostic, LinterConfiguration, PartialConfiguration,
 };
 use pg_fs::FileSystem;

--- a/crates/pg_workspace/src/workspace/server.rs
+++ b/crates/pg_workspace/src/workspace/server.rs
@@ -1,10 +1,4 @@
-use std::{
-    fs,
-    future::Future,
-    panic::RefUnwindSafe,
-    path::{Path, PathBuf},
-    sync::RwLock,
-};
+use std::{fs, future::Future, panic::RefUnwindSafe, path::Path, sync::RwLock};
 
 use analyser::AnalyserVisitorBuilder;
 use change::StatementChange;


### PR DESCRIPTION
fixes #184 

also using `TextSize` now. but we might want to revisit the lexer at some point because I dont think we should store the text in the tokens anymore.