### PR TITLE
fix(pglt_workspace): lock

### DIFF
--- a/crates/pglt_lsp/src/session.rs
+++ b/crates/pglt_lsp/src/session.rs
@@ -267,8 +267,6 @@ impl Session {
                 skip: Vec::new(),
             })?;
 
-            tracing::trace!("pglt diagnostics: {:#?}", result.diagnostics);
-
             result
                 .diagnostics
                 .into_iter()
@@ -289,8 +287,6 @@ impl Session {
                 })
                 .collect()
         };
-
-        tracing::Span::current().record("diagnostic_count", diagnostics.len());
 
         self.client
             .publish_diagnostics(url, diagnostics, Some(doc.version))


### PR DESCRIPTION
fixes our bug from last night. the issue was actually that the entire server went into a lock when loading the `SchemaCache` for auto-completion, because we did not release the read lock on `inner` before acquiring the write lock. I wonder how we could write a test for these kind of issues 🤔 maybe some kind of simulation e2e test where we actually start the server and start to send some commands and then stop it again. 

also removed some spammy logs.