### PR TITLE
docs: add short guide for migrations

### DIFF
--- a/docs/checking_migrations.md
+++ b/docs/checking_migrations.md
@@ -1,0 +1,27 @@
+# Linting Migrations
+
+Postgres Language Tools comes with a `check` command that can be integrated into your development workflow to prevent unexpected downtime caused by database migrations and encourage best practices around Postgres schemas and SQL.
+
+To run it, simply point at your migrations directory.
+
+```sh
+pglt check supabase/migrations
+```
+
+When you are setting it up in an existing project, you might want to ignore all migrations that are already applied. To do so, add `migrations_dir` and `after` to your `pglt.toml` file
+
+
+```toml
+[migrations]
+migrations_dir = "supabase/migrations"
+after = 1740868021
+```
+
+or pass it directly to the command
+
+```
+pglt check supabase/migrations --migrations-dir="supabase/migrations" --after=1740868021
+```
+
+This will only check migrations after the specified timestamp.
+

--- a/docs/checking_migrations.md
+++ b/docs/checking_migrations.md
@@ -1,6 +1,6 @@
 # Linting Migrations
 
-Postgres Language Tools comes with a `check` command that can be integrated into your development workflow to prevent unexpected downtime caused by database migrations and encourage best practices around Postgres schemas and SQL.
+Postgres Language Tools comes with a `check` command that can be integrated into your development workflow to catch problematic schema changes and encourage best practices.
 
 To run it, simply point at your migrations directory.
 
@@ -17,11 +17,13 @@ migrations_dir = "supabase/migrations"
 after = 1740868021
 ```
 
-or pass it directly to the command
+Alternatively, pass them directly.
 
 ```
 pglt check supabase/migrations --migrations-dir="supabase/migrations" --after=1740868021
 ```
 
 This will only check migrations after the specified timestamp.
+
+For pre-commit hooks and when working locally, use `--staged` to only lint files that have been staged. In CI environments, you most likely want to use `--changed` to only lint files that have been changed compared to your `defaultBranch` configuration. If `defaultBranch` is not set in your `pglt.toml`, use `--since=REF` to specify the base branch to compare against.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,9 @@ Make sure to point the database connection settings at your local development da
 
 ## Usage
 
-You can check SQL files using the `check` command:
+You can use the language tools either via CLI or a Language Server.
+
+The CLI exposes a simple `check` command that will run all checks on the given files or paths.
 
 ```sh
 pglt check myfile.sql


### PR DESCRIPTION
We should also add a section for --since and --changes 