### PR TITLE
fix: emit whitespace changes after all

### DIFF
--- a/crates/pglt_completions/src/providers/columns.rs
+++ b/crates/pglt_completions/src/providers/columns.rs
@@ -72,13 +72,13 @@ mod tests {
                 message: "correctly handles nested queries",
                 query: format!(
                     r#"
-                select 
+                select
                     *
                 from (
                     select id, na{}
                     from private.audio_books
                 ) as subquery
-                join public.users u 
+                join public.users u
                 on u.id = subquery.id;
                 "#,
                     CURSOR_POS

--- a/crates/pglt_completions/src/providers/functions.rs
+++ b/crates/pglt_completions/src/providers/functions.rs
@@ -29,7 +29,7 @@ mod tests {
     #[tokio::test]
     async fn completes_fn() {
         let setup = r#"
-          create or replace function cool() 
+          create or replace function cool()
           returns trigger
           language plpgsql
           security invoker
@@ -62,7 +62,7 @@ mod tests {
             name text
           );
 
-          create or replace function cool() 
+          create or replace function cool()
           returns trigger
           language plpgsql
           security invoker
@@ -96,7 +96,7 @@ mod tests {
             name text
           );
 
-          create or replace function cool() 
+          create or replace function cool()
           returns trigger
           language plpgsql
           security invoker
@@ -130,7 +130,7 @@ mod tests {
             name text
           );
 
-          create or replace function cool() 
+          create or replace function cool()
           returns trigger
           language plpgsql
           security invoker

--- a/crates/pglt_completions/src/providers/tables.rs
+++ b/crates/pglt_completions/src/providers/tables.rs
@@ -148,7 +148,7 @@ mod tests {
             name text
           );
 
-          create or replace function cool() 
+          create or replace function cool()
           returns trigger
           language plpgsql
           security invoker

--- a/crates/pglt_workspace/src/workspace/server/change.rs
+++ b/crates/pglt_workspace/src/workspace/server/change.rs
@@ -278,28 +278,25 @@ impl Document {
                 let new_id = self.id_generator.next();
                 self.positions[affected_idx] = (new_id, new_range);
 
-                if !change.is_whitespace() {
-                    // whitespace-only changes should not invalidate the statement
-                    changed.push(StatementChange::Modified(ModifiedStatement {
-                        old_stmt: Statement {
-                            id: old_id,
-                            path: self.path.clone(),
-                        },
-                        old_stmt_text: self.content[old_range].to_string(),
+                changed.push(StatementChange::Modified(ModifiedStatement {
+                    old_stmt: Statement {
+                        id: old_id,
+                        path: self.path.clone(),
+                    },
+                    old_stmt_text: self.content[old_range].to_string(),
 
-                        new_stmt: Statement {
-                            id: new_id,
-                            path: self.path.clone(),
-                        },
-                        new_stmt_text: changed_content[new_ranges[0]].to_string(),
-                        // change must be relative to the statement
-                        change_text: change.text.clone(),
-                        // make sure we always have a valid range >= 0
-                        change_range: change_range
-                            .checked_sub(old_range.start())
-                            .unwrap_or(change_range.sub(change_range.start())),
-                    }));
-                }
+                    new_stmt: Statement {
+                        id: new_id,
+                        path: self.path.clone(),
+                    },
+                    new_stmt_text: changed_content[new_ranges[0]].to_string(),
+                    // change must be relative to the statement
+                    change_text: change.text.clone(),
+                    // make sure we always have a valid range >= 0
+                    change_range: change_range
+                        .checked_sub(old_range.start())
+                        .unwrap_or(change_range.sub(change_range.start())),
+                }));
 
                 self.content = new_content;
 
@@ -375,10 +372,6 @@ impl Document {
 }
 
 impl ChangeParams {
-    pub fn is_whitespace(&self) -> bool {
-        self.text.chars().count() > 0 && self.text.chars().all(char::is_whitespace)
-    }
-
     pub fn diff_size(&self) -> TextSize {
         match self.range {
             Some(range) => {

--- a/crates/pglt_workspace/src/workspace/server/change.rs
+++ b/crates/pglt_workspace/src/workspace/server/change.rs
@@ -657,7 +657,7 @@ mod tests {
         };
 
         let changed1 = d.apply_file_change(&change1);
-        assert_eq!(changed1.len(), 0, "should not emit change");
+        assert_eq!(changed1.len(), 1);
         assert_eq!(
             d.content,
             "alter table deal  alter column value drop not null;\n"
@@ -674,7 +674,7 @@ mod tests {
         };
 
         let changed2 = d.apply_file_change(&change2);
-        assert_eq!(changed2.len(), 0);
+        assert_eq!(changed2.len(), 1);
         assert_eq!(
             d.content,
             "alter table deal   alter column value drop not null;\n"
@@ -691,7 +691,7 @@ mod tests {
         };
 
         let changed3 = d.apply_file_change(&change3);
-        assert_eq!(changed3.len(), 0);
+        assert_eq!(changed3.len(), 1);
         assert_eq!(
             d.content,
             "alter table deal    alter column value drop not null;\n"
@@ -708,7 +708,7 @@ mod tests {
         };
 
         let changed4 = d.apply_file_change(&change4);
-        assert_eq!(changed4.len(), 0);
+        assert_eq!(changed4.len(), 1);
         assert_eq!(
             d.content,
             "alter table deal     alter column value drop not null;\n"
@@ -734,11 +734,7 @@ mod tests {
         };
 
         let changed1 = d.apply_file_change(&change1);
-        assert_eq!(
-            changed1.len(),
-            0,
-            "should not emit change if its only whitespace"
-        );
+        assert_eq!(changed1.len(), 1);
         assert_eq!(
             d.content,
             "select\n  *\nfrom\n  test;\n\nselect \n\nalter table test\n\ndrop column id;"
@@ -860,7 +856,7 @@ mod tests {
 
         let changed = d.apply_file_change(&change);
 
-        assert_eq!(changed.len(), 0);
+        assert_eq!(changed.len(), 1);
 
         assert_document_integrity(&d);
     }


### PR DESCRIPTION
after some forth and back yesterday and a crash when starting to complete after a change I realised I am big idiot because not emitting whitespaces will result in an invalid tree sitter tree… 🥲 so yeah, we just emit them now. also added an e2e test for completions.

also
- removed changed statements because we do not use them and they will jus grow over time 
- my format-on-write did minor changes to the sql in tests 